### PR TITLE
fix: Modify unit test to be able to validate the exist of is_showing checkbox.

### DIFF
--- a/tests/Feature/LaravelStations/Station10/AdminMovieTest.php
+++ b/tests/Feature/LaravelStations/Station10/AdminMovieTest.php
@@ -130,7 +130,7 @@ class AdminMovieTest extends TestCase
         $response->assertSee($movie->image_url);
         $response->assertSee($movie->published_year);
         $response->assertSee($movie->description);
-        $response->assertSee($movie->is_showing ? '上映中' : '上映予定');
+        $response->assertSee('is_showing'); // Checkboxの存在を確認する代わりにプロパティ名がHTMLに含まれているかどうかだけチェックする
     }
 
     public function test管理者映画編集画面で映画が更新されるか(): void

--- a/tests/Feature/LaravelStations/Station11/AdminMovieTest.php
+++ b/tests/Feature/LaravelStations/Station11/AdminMovieTest.php
@@ -148,7 +148,7 @@ class AdminMovieTest extends TestCase
         $response->assertSee($movie->image_url);
         $response->assertSee($movie->published_year);
         $response->assertSee($movie->description);
-        $response->assertSee($movie->is_showing ? '上映中' : '上映予定');
+        $response->assertSee('is_showing'); // Checkboxの存在を確認する代わりにプロパティ名がHTMLに含まれているかどうかだけチェックする
     }
 
     /**

--- a/tests/Feature/LaravelStations/Station12/AdminMovieTest.php
+++ b/tests/Feature/LaravelStations/Station12/AdminMovieTest.php
@@ -173,7 +173,7 @@ class AdminMovieTest extends TestCase
         $response->assertSee($movie->image_url);
         $response->assertSee($movie->published_year);
         $response->assertSee($movie->description);
-        $response->assertSee($movie->is_showing ? '上映中' : '上映予定');
+        $response->assertSee('is_showing'); // Checkboxの存在を確認する代わりにプロパティ名がHTMLに含まれているかどうかだけチェックする
         $response->assertSee($movie->genre->name);
     }
 

--- a/tests/Feature/LaravelStations/Station13/AdminMovieTest.php
+++ b/tests/Feature/LaravelStations/Station13/AdminMovieTest.php
@@ -173,7 +173,7 @@ class AdminMovieTest extends TestCase
         $response->assertSee($movie->image_url);
         $response->assertSee($movie->published_year);
         $response->assertSee($movie->description);
-        $response->assertSee($movie->is_showing ? '上映中' : '上映予定');
+        $response->assertSee('is_showing'); // Checkboxの存在を確認する代わりにプロパティ名がHTMLに含まれているかどうかだけチェックする
         $response->assertSee($movie->genre->name);
     }
 

--- a/tests/Feature/LaravelStations/Station14/AdminMovieTest.php
+++ b/tests/Feature/LaravelStations/Station14/AdminMovieTest.php
@@ -173,7 +173,7 @@ class AdminMovieTest extends TestCase
         $response->assertSee($movie->image_url);
         $response->assertSee($movie->published_year);
         $response->assertSee($movie->description);
-        $response->assertSee($movie->is_showing ? '上映中' : '上映予定');
+        $response->assertSee('is_showing'); // Checkboxの存在を確認する代わりにプロパティ名がHTMLに含まれているかどうかだけチェックする
         $response->assertSee($movie->genre->name);
     }
 

--- a/tests/Feature/LaravelStations/Station15/AdminMovieTest.php
+++ b/tests/Feature/LaravelStations/Station15/AdminMovieTest.php
@@ -173,7 +173,7 @@ class AdminMovieTest extends TestCase
         $response->assertSee($movie->image_url);
         $response->assertSee($movie->published_year);
         $response->assertSee($movie->description);
-        $response->assertSee($movie->is_showing ? '上映中' : '上映予定');
+        $response->assertSee('is_showing'); // Checkboxの存在を確認する代わりにプロパティ名がHTMLに含まれているかどうかだけチェックする
         $response->assertSee($movie->genre->name);
     }
 

--- a/tests/Feature/LaravelStations/Station16/AdminMovieTest.php
+++ b/tests/Feature/LaravelStations/Station16/AdminMovieTest.php
@@ -173,7 +173,7 @@ class AdminMovieTest extends TestCase
         $response->assertSee($movie->image_url);
         $response->assertSee($movie->published_year);
         $response->assertSee($movie->description);
-        $response->assertSee($movie->is_showing ? '上映中' : '上映予定');
+        $response->assertSee('is_showing'); // Checkboxの存在を確認する代わりにプロパティ名がHTMLに含まれているかどうかだけチェックする
         $response->assertSee($movie->genre->name);
     }
 

--- a/tests/Feature/LaravelStations/Station17/AdminMovieTest.php
+++ b/tests/Feature/LaravelStations/Station17/AdminMovieTest.php
@@ -173,7 +173,7 @@ class AdminMovieTest extends TestCase
         $response->assertSee($movie->image_url);
         $response->assertSee($movie->published_year);
         $response->assertSee($movie->description);
-        $response->assertSee($movie->is_showing ? '上映中' : '上映予定');
+        $response->assertSee('is_showing'); // Checkboxの存在を確認する代わりにプロパティ名がHTMLに含まれているかどうかだけチェックする
         $response->assertSee($movie->genre->name);
     }
 

--- a/tests/Feature/LaravelStations/Station18/AdminMovieTest.php
+++ b/tests/Feature/LaravelStations/Station18/AdminMovieTest.php
@@ -173,7 +173,7 @@ class AdminMovieTest extends TestCase
         $response->assertSee($movie->image_url);
         $response->assertSee($movie->published_year);
         $response->assertSee($movie->description);
-        $response->assertSee($movie->is_showing ? '上映中' : '上映予定');
+        $response->assertSee('is_showing'); // Checkboxの存在を確認する代わりにプロパティ名がHTMLに含まれているかどうかだけチェックする
         $response->assertSee($movie->genre->name);
     }
 

--- a/tests/Feature/LaravelStations/Station19/AdminMovieTest.php
+++ b/tests/Feature/LaravelStations/Station19/AdminMovieTest.php
@@ -173,7 +173,7 @@ class AdminMovieTest extends TestCase
         $response->assertSee($movie->image_url);
         $response->assertSee($movie->published_year);
         $response->assertSee($movie->description);
-        $response->assertSee($movie->is_showing ? '上映中' : '上映予定');
+        $response->assertSee('is_showing'); // Checkboxの存在を確認する代わりにプロパティ名がHTMLに含まれているかどうかだけチェックする
         $response->assertSee($movie->genre->name);
     }
 

--- a/tests/Feature/LaravelStations/Station9/AdminMovieTest.php
+++ b/tests/Feature/LaravelStations/Station9/AdminMovieTest.php
@@ -130,7 +130,7 @@ class AdminMovieTest extends TestCase
         $response->assertSee($movie->image_url);
         $response->assertSee($movie->published_year);
         $response->assertSee($movie->description);
-        $response->assertSee($movie->is_showing ? '上映中' : '上映予定');
+        $response->assertSee('is_showing'); // Checkboxの存在を確認する代わりにプロパティ名がHTMLに含まれているかどうかだけチェックする
     }
 
     public function test管理者映画編集画面で映画が更新されるか(): void


### PR DESCRIPTION
### Fact

Laravel Railway Station9 (9以降も同様) の問題文では、チェックボックスをつかって is_showing を実装する指示がある。
https://techtrain.dev/mypage/railway/27/station/667

元のテストコードは `$response->assertSee($movie->is_showing ? '上映中' : '上映予定');` と、select 要素を想定したものになっていた。

### Fix

input 要素のテストとして <input type="checkbox" /> を取りたいが、attributesの順番は強制できないので、やむなく "is_showing" という文字列がHTMLに含まれていることだけを評価するものとした。

### Other

代案歓迎！
