### PR TITLE
composeの記法をアップデート

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,8 +1,3 @@
-version: "3.9"
-volumes:
-    laravel-railway-mysql-data:
-        driver: local
-
 services:
     nginx-container:
         image: nginx
@@ -91,3 +86,7 @@ services:
         environment:
             ADMINER_DEFAULT_SERVER: mysql-container
             ADMINER_DESIGN: galkaev
+
+volumes:
+    laravel-railway-mysql-data:
+        driver: local

--- a/server/docker/php/Dockerfile
+++ b/server/docker/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-fpm-bullseye
+FROM php:8.3-fpm-bookworm
 
 # For composer
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
### Why

下記のようにフォーラムで何度も問い合わせがくるので、対応したい。
警告文ではあるため、実際には稼働するのだが、何度も問い合わせがくる状態を解消したい。


### What

- composeの記法を最新に変更
   - version指定の書き方を廃止
- phpのバージョンを最新に変更

### QA

`level=warning msg="docker-compose.yml: the attribute version is obsolete, it will be ignored, please remove it to avoid potential confusion"` という警告文が出ていないことを確認。

```sh
laravel-stations-2 on  update/compose via  v22.2.0 via 🐘
❯ docker compose up -d
[+] Running 6/6
 ✔ Container laravel-stations-2-adminer-1              Running                                                                                                                                              0.0s
 ✔ Container laravel-stations-2-yarn-installation      Started                                                                                                                                              0.7s
 ✔ Container laravel-stations-2-composer-installation  Started                                                                                                                                              0.5s
 ✔ Container laravel-stations-2-php                    Started                                                                                                                                              1.3s
 ✔ Container laravel-stations-2-mysql                  Started                                                                                                                                              0.9s
 ✔ Container laravel-stations-2-nginx                  Started                                                                                                                                              1.9s

```