### PR TITLE
PHPUnit v11以降に対応するため、DataProviderアトリビュートを利用するように変更

### DIFF
--- a/tests/Feature/LaravelStations/Station20/ScreenTest.php
+++ b/tests/Feature/LaravelStations/Station20/ScreenTest.php
@@ -10,6 +10,7 @@ use App\Models\Sheet;
 use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ScreenTest extends TestCase
 {
@@ -145,9 +146,7 @@ class ScreenTest extends TestCase
         ]);
     }
 
-    /**
-     * @dataProvider reservationPatternProvider
-     */
+    #[DataProvider('reservationPatternProvider')]
     public function test座席予約が実行できる(
         array $schedule1Data,
         array $schedule2Data,
@@ -181,7 +180,7 @@ class ScreenTest extends TestCase
         }
     }
 
-    public function reservationPatternProvider(): array
+    public static function reservationPatternProvider(): array
     {
         $users_data = [
             [

--- a/tests/Feature/LaravelStations/Station21/AuthenticationTest.php
+++ b/tests/Feature/LaravelStations/Station21/AuthenticationTest.php
@@ -11,6 +11,7 @@ use App\Models\User;
 use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class AuthenticationTest extends TestCase
 {
@@ -64,9 +65,7 @@ class AuthenticationTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider unAuthenticatedRouteProvider
-     */
+    #[DataProvider('unAuthenticatedRouteProvider')]
     public function test非ログイン時に認証が必要なページがアクセス制限され_loginページにリダイレクトされる(string $route): void
     {
         // プレースホルダーを実際の値に置換
@@ -76,7 +75,7 @@ class AuthenticationTest extends TestCase
         $response->assertRedirect('/login');
     }
 
-    public function unAuthenticatedRouteProvider(): array
+    public static function unAuthenticatedRouteProvider(): array
     {
         return [
             '映画一覧ページ' => ['/movies'],
@@ -87,9 +86,7 @@ class AuthenticationTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider unAuthenticatedPostRouteProvider
-     */
+    #[DataProvider('unAuthenticatedPostRouteProvider')]
     public function test非ログイン時に認証が必要なPOSTリクエストがアクセス制限され_loginページにリダイレクトされる(string $route, array $params): void
     {
         // プレースホルダーを実際の値に置換
@@ -102,7 +99,7 @@ class AuthenticationTest extends TestCase
         $response->assertRedirect('/login');
     }
 
-    public function unAuthenticatedPostRouteProvider(): array
+    public static function unAuthenticatedPostRouteProvider(): array
     {
         return [
             '予約保存処理' => [


### PR DESCRIPTION
## Why

PHPUnit v11以降では非推奨になった書き方が、Station20とStation21の2つに存在する。
DataProviderアノテーションだと実行時にエラーになってしまうので、DataProviderアトリビュートを利用したい。

## What

DataProviderアトリビュートを利用するように変更

### 補足

下記のように記述する必要があります。

```php
use PHPUnit\Framework\Attributes\DataProvider;

// 略

#[DataProvider('attributeProvider')]
public function レンタカーの予約である(bool $result, int $value)
{
    // 略
}

/**
 * @return array
 */
public static function attributeProvider(): array
{
    // 略
}
```

refs: 
- https://github.com/sebastianbergmann/phpunit/commit/9caafe2d49b33a21f87db248a8ad6ca7c7bdac09
- https://docs.phpunit.de/en/12.0/writing-tests-for-phpunit.html#writing-tests-for-phpunit-data-providers