### PR TITLE
test(station11): 映画一覧での検索実行時ページネーションリンクが検索条件を保持することを担保

### DIFF
--- a/tests/Feature/LaravelStations/Station11/MovieTest.php
+++ b/tests/Feature/LaravelStations/Station11/MovieTest.php
@@ -147,4 +147,28 @@ class MovieTest extends TestCase
             ],
         ];
     }
+
+    #[Test]
+    #[Group('station11')]
+    public function test_映画一覧での検索時_ページネーションリンクに検索条件が含まれている(): void
+    {
+        foreach (range(0, 20) as $value) {
+            Movie::insert([
+                'title' => 'title' . $value,
+                'image_url' => 'https://techbowl.co.jp/_nuxt/img/6074f79.png',
+                'published_year' => 2000,
+                'description' => '概要',
+                'is_showing' => true,
+            ]);
+        }
+
+        $response = $this->get('/movies?keyword=title&is_showing=1');
+
+        $matches = [];
+        preg_match('/href="([^"]*page=2[^"]*)"/', $response->getContent(), $matches);
+        $this->assertNotEmpty($matches, 'ページネーションリンクが存在しません');
+        $href = $matches[1];
+        $this->assertStringContainsString('keyword=title', $href);
+        $this->assertStringContainsString('is_showing=1', $href);
+    }
 }


### PR DESCRIPTION
## 概要

Station11 MovieTest について、ご指摘頂いた内容を踏まえたテストケースを追加

### ご指摘頂いた問題

Pagination, 検索条件のテストケースはそれぞれ存在するが、両方を組み合わせたテストケースがなく、「検索時に 2 ページ目以降検索条件が反映されない」不具合をテストで検出できていない

### 追加したテストケース

検索条件をセットした 1 ページ目取得時、生成されたページネーションリンクの 2 ページ目リンクに検索条件が含まれていることを担保


